### PR TITLE
Newline before first use

### DIFF
--- a/php_companion/commands/import_use_command.py
+++ b/php_companion/commands/import_use_command.py
@@ -21,7 +21,7 @@ class ImportUseCommand(sublime_plugin.TextCommand):
         region = self.view.find(where, 0)
         if not region.empty():
             line = self.view.line(region)
-            self.view.insert(edit, line.end(), "\n" + self.build_uses())
+            self.view.insert(edit, line.end(), "\n\n" + self.build_uses())
             sublime.status_message('Successfully imported' + self.namespace)
 
     def insert_use_among_others(self, edit):


### PR DESCRIPTION
Currently the `use` statement is imported right after the `namespace` or
`<?php`

I don't really like it and I know I'm not the only one around here :)

So I added an option in the configuration file to add that newline or
not (default set to false to keep current behavior, but feel free to
change that)
