### PR TITLE
Remove unnecessary leading namespace separator.

### DIFF
--- a/php_companion/utils.py
+++ b/php_companion/utils.py
@@ -51,6 +51,6 @@ def find_in_global_namespace(symbol):
     matches = []
     for phpClass in definedClasses:
         if symbol == phpClass:
-            matches.append(['\\' + phpClass, '\\' + phpClass])
+            matches.append([phpClass, phpClass])
 
     return matches


### PR DESCRIPTION
As it currently stands, global namespace classes are imported like so:

``` php
use \PDO;            // global namespace import
use Vendor\Package;  // non-global namespace import
```

But leading namespace separators are meaningless in use statements, and it breaks consistency with non-global imports.

This PR brings global namespace imports inline with the others, like so:

``` php
use PDO;             // global namespace import
use Vendor\Package;  // non-global namespace import
```
