### PR TITLE
Add docblock for methods when implements

### DIFF
--- a/PHP Companion.sublime-settings
+++ b/PHP Companion.sublime-settings
@@ -17,6 +17,10 @@
     // command. "public", "protected" or "private"
     "visibility": "private",
 
+    // Copy comment doc from parent or interface to implemented class
+    // "true" or "inheritdoc".
+    "docblock_inherit": true,
+
     "padawan_composer": "composer",
     "padawan_timeout": 0.5
 }

--- a/php_companion/commands/parse.py
+++ b/php_companion/commands/parse.py
@@ -19,7 +19,7 @@ class ParseCommand(sublime_plugin.TextCommand):
             content = f.read()
 
         # Get the methods from the content
-        self.methods = re.findall("(?<!\* )(?:abstract )?(?:public|protected|private)(?: static)? function [A-z0-9]*\([A-z0-9$=, ]*\)[A-z :]*", content)
+        self.methods = re.findall("(?<!\* )(?:abstract )?((?:public|protected|private)(?: static)? function [A-z0-9]*\([A-z0-9$=, ]*\)[A-z :]*)", content)
         self.methods.insert(0, 'Insert all methods')
 
         # Show the available methods in the quick panel

--- a/php_companion/commands/parse.py
+++ b/php_companion/commands/parse.py
@@ -18,9 +18,9 @@ class ParseCommand(sublime_plugin.TextCommand):
         with open(self.normalize_to_system_style_path(path), "r") as f:
             content = f.read()
 
-        pattern = "(?<!\* )(?:abstract )?((?:public|protected|private)(?: static)? function [A-z0-9]*\([A-z0-9$=, ]*\)[A-z :]*)"
+        pattern = "(?<!\* )(?:abstract )?((?:public|protected|private)(?: static)? function [\w]+\s*\(.*?\))\s*;"
         # Get the methods from the content
-        self.methods = re.findall(pattern, content)
+        self.methods = re.findall(pattern, content, re.S)
 
         # find comment docblocks
         self.method_docblocks = {}
@@ -28,7 +28,7 @@ class ParseCommand(sublime_plugin.TextCommand):
             pos = content.index(m)
             try:
                 end = content.rindex("*/", 0, pos)
-                if re.findall(pattern, content[end:pos]) or re.findall("(interface|abstract([A-Z0-9\s]+)class)\s+[A-Z0-9]+", content[end:pos]):
+                if re.findall(pattern, content[end:pos], re.S) or re.findall("(interface|abstract([A-Z0-9\s]+)class)\s+[A-Z0-9]+", content[end:pos]):
                     self.method_docblocks[m] = None
                     continue
 

--- a/php_companion/commands/parse.py
+++ b/php_companion/commands/parse.py
@@ -1,5 +1,7 @@
 import sublime, sublime_plugin, re
 
+from ..settings import get_setting
+
 class ParseCommand(sublime_plugin.TextCommand):
 
     # Normalizes a given path to the current system style
@@ -64,9 +66,9 @@ class ParseCommand(sublime_plugin.TextCommand):
             methods = ""
             for method in self.methods[1:]:
                 if self.method_docblocks[method] != None:
-                    if self.view.settings().get("docblock_inherit") == True:
+                    if get_setting("docblock_inherit") == True:
                         method = self.method_docblocks[method] + "\n\t" + method
-                    elif self.view.settings().get("docblock_inherit") == "inheritdoc":
+                    elif get_setting("docblock_inherit") == "inheritdoc":
                         method = "\n\t".join(["/**", " * {@inheirtdoc}", "*/"]) + "\n\t" + method
 
                 methods += template.format(method)
@@ -74,10 +76,10 @@ class ParseCommand(sublime_plugin.TextCommand):
             self.view.run_command("create", {"stub": methods, "offset": point})
         else:
             method = self.methods[index]
-            if self.view.settings().get("docblock_inherit") == True:
+            if get_setting("docblock_inherit") == True:
                 if self.method_docblocks[method] != None:
                     method = self.method_docblocks[method] + "\n\t" + method
-            elif self.view.settings().get("docblock_inherit") == "inheritdoc":
+            elif get_setting("docblock_inherit") == "inheritdoc":
                 method = "\n\t".join(["/**", " * {@inheirtdoc}", "*/"]) + "\n\t" + method
 
             method_stub = template.format(method)

--- a/php_companion/commands/parse.py
+++ b/php_companion/commands/parse.py
@@ -80,7 +80,7 @@ class ParseCommand(sublime_plugin.TextCommand):
                 if self.method_docblocks[method] != None:
                     method = self.method_docblocks[method] + "\n\t" + method
             elif get_setting("docblock_inherit") == "inheritdoc":
-                method = "\n\t".join(["/**", " * {@inheirtdoc}", "*/"]) + "\n\t" + method
+                method = "\n\t".join(["/**", " * {@inheritdoc}", "*/"]) + "\n\t" + method
 
             method_stub = template.format(method)
             self.view.run_command("create", {"stub": method_stub, "offset": point})

--- a/php_companion/settings.py
+++ b/php_companion/settings.py
@@ -6,6 +6,11 @@ def filename():
 def get_setting(name, default=None):
     project_data = sublime.active_window().project_data()
 
+    # setting in run time
+    view_setting = sublime.active_window().active_view().settings().get(name, None)
+    if view_setting != None:
+        return view_setting
+
     if (project_data and 'phpcompanion' in project_data and
             name in project_data['phpcompanion']):
         return project_data['phpcompanion'][name]


### PR DESCRIPTION
- Remove "abstract" keyword when implements
- Copy docblock from interface, abstract methods to impelmented class to make it more clear.