### PR TITLE
Support for importing pre-defined interfaces from the global namespace.

### DIFF
--- a/php_companion/utils.py
+++ b/php_companion/utils.py
@@ -46,7 +46,7 @@ def find_symbol(symbol, window):
     return namespacesArray
 
 def find_in_global_namespace(symbol):
-    definedClasses = subprocess.check_output(["php", "-r", "echo json_encode(get_declared_classes());"]);
+    definedClasses = subprocess.check_output(["php", "-r", "echo json_encode(array_merge(get_declared_classes(), get_declared_interfaces()));"]);
     definedClasses = definedClasses.decode('utf-8')
     definedClasses = json.loads(definedClasses)
     definedClasses.sort()


### PR DESCRIPTION
This PR adds interfaces to the list of types that can be imported from the global namespace.

You might remember me from 4 years ago (😮) when I raised #13/#14, and I can't believe it's taken me so long to submit a PR to fix this!

Basically, when #13 was addressed, you ended up using [get_declared_classes()](http://php.net/get_declared_classes), which covers classes, but not interfaces. To include interfaces you also need [get_declared_interfaces()](http://php.net/get_declared_interfaces).

Note that ever since PHP 5.4, there is also [get_declared_traits()](http://php.net/get_declared_traits), but there are currently no traits in the PHP standard library, and since it would require some tricks to continue 5.3 support, I decided not to add that in this PR.