### PR TITLE
Sort use statements in a case-insensitive manner.

### DIFF
--- a/php_companion/commands/import_use_command.py
+++ b/php_companion/commands/import_use_command.py
@@ -50,7 +50,7 @@ class ImportUseCommand(sublime_plugin.TextCommand):
         self.view.find_all(r"^(use\s+.+[;])", 0, '$1', uses)
         uses.append(use_stmt)
         uses = list(set(uses))
-        uses.sort()
+        uses.sort(key = str.lower)
         if get_setting("use_sort_length"):
             uses.sort(key = len)
 


### PR DESCRIPTION
Relates to #105.

This PR goes part-way to bringing use statement ordering inline with PHP-CS-Fixer. It simply changes the use statement ordering to be case-insensitive.

Disclaimer: I have not actually tested this code (sorry), and I don't know Python at all.