### PR TITLE
added os check for windows to not show php process window

### DIFF
--- a/php_companion/utils.py
+++ b/php_companion/utils.py
@@ -52,7 +52,7 @@ def find_in_global_namespace(symbol):
         startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
     definedClasses = subprocess.check_output(
-        ["php", "-r", "echo json_encode(get_declared_classes());"],
+        ["php", "-r", "echo json_encode(array_merge(get_declared_classes(), get_declared_interfaces()));"],
         startupinfo=startupinfo
     )
 

--- a/php_companion/utils.py
+++ b/php_companion/utils.py
@@ -1,5 +1,5 @@
 import sublime
-
+import os
 import re
 import mmap
 import contextlib
@@ -46,7 +46,16 @@ def find_symbol(symbol, window):
     return namespacesArray
 
 def find_in_global_namespace(symbol):
-    definedClasses = subprocess.check_output(["php", "-r", "echo json_encode(get_declared_classes());"]);
+    startupinfo = subprocess.STARTUPINFO()
+
+    if os.name == 'nt':
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+
+    definedClasses = subprocess.check_output(
+        ["php", "-r", "echo json_encode(get_declared_classes());"],
+        startupinfo=startupinfo
+    )
+
     definedClasses = definedClasses.decode('utf-8')
     definedClasses = json.loads(definedClasses)
     definedClasses.sort()


### PR DESCRIPTION
In windows the PHP process cmd window popped up for a flash when `allow_use_from_global_namespace` was on (used to check declared classes).

This hides the window from showing up.

Also included #103 