### PR TITLE
Fix parse methods if last agrument is array()

### DIFF
--- a/php_companion/commands/parse.py
+++ b/php_companion/commands/parse.py
@@ -20,7 +20,7 @@ class ParseCommand(sublime_plugin.TextCommand):
         with open(self.normalize_to_system_style_path(path), "r") as f:
             content = f.read()
 
-        pattern = "(?<!\* )(?:abstract )?((?:public|protected|private)(?: static)?\s+function\s+[\w]+\s*\(.*?\)(?:\s*\:\s*\w+)?)(?:\s*;|.*?{)"
+        pattern = "(?<!\* )(?:abstract )?((?:public|protected|private)(?: static)?\s+function\s+[\w]+\s*\(.*?\)(?:\s*\:\s*\w+)?)(?:\s*;|\s*{)"
         # Get the methods from the content
         self.methods = re.findall(pattern, content, re.S)
 


### PR DESCRIPTION
In case abstract method is

`public function methodName($abc, array $options = array()) {}`

It will add implement code as:
`public function methodName($abc, array $options = array()` 
but it should be
`public function methodName($abc, array $options = array())`
