### PR TITLE
add support for classes that are inside annotations

### DIFF
--- a/php_companion/commands/expand_fqcn_command.py
+++ b/php_companion/commands/expand_fqcn_command.py
@@ -11,6 +11,11 @@ class ExpandFqcnCommand(sublime_plugin.TextCommand):
         self.region = view.word(view.sel()[0])
         symbol = view.substr(self.region)
 
+        self.has_at = False
+        if symbol.startswith('@'):
+            self.has_at = True
+            symbol = symbol.replace('@', '')
+
         if re.match(r"\w", symbol) is None:
             return sublime.status_message('Not a valid symbol "%s" !' % symbol)
 
@@ -18,7 +23,11 @@ class ExpandFqcnCommand(sublime_plugin.TextCommand):
         self.leading_separator = leading_separator
 
         if len(self.namespaces) == 1:
-            self.view.run_command("replace_fqcn", {"region_start": self.region.begin(), "region_end": self.region.end(), "namespace": self.namespaces[0][0], "leading_separator": self.leading_separator})
+            _ns = self.namespaces[0][0]
+            if self.has_at:
+                _ns = '@{}'.format(_ns)
+
+            self.view.run_command("replace_fqcn", {"region_start": self.region.begin(), "region_end": self.region.end(), "namespace": _ns, "leading_separator": self.leading_separator})
 
         if len(self.namespaces) > 1:
             view.window().show_quick_panel(self.namespaces, self.on_done)
@@ -27,4 +36,8 @@ class ExpandFqcnCommand(sublime_plugin.TextCommand):
         if index == -1:
             return
 
-        self.view.run_command("replace_fqcn", {"region_start": self.region.begin(), "region_end": self.region.end(), "namespace": self.namespaces[index][0], "leading_separator": self.leading_separator})
+        _ns = self.namespaces[index][0]
+        if self.has_at:
+            _ns = '@{}'.format(_ns)
+
+        self.view.run_command("replace_fqcn", {"region_start": self.region.begin(), "region_end": self.region.end(), "namespace": _ns, "leading_separator": self.leading_separator})

--- a/php_companion/commands/find_use_command.py
+++ b/php_companion/commands/find_use_command.py
@@ -10,6 +10,8 @@ class FindUseCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         view = self.view
         symbol = view.substr(view.word(view.sel()[0]))
+        if symbol.startswith('@'):
+            symbol = symbol.replace('@', '')
 
         if re.match(r"\w", symbol) is None:
             return sublime.status_message('Not a valid symbol "%s" !' % symbol)


### PR DESCRIPTION
Problem:
Expand_fqcn and find_use commands are expecting words.

Annotations like Route or ORM while using a webframework like symfony have the @ prepended to the class name

Solution:
find_use: ignore the @ by removing it
expand_fqnc: keep track of @ if it exists and prepended it on selection.