### PR TITLE
Fix incorrect @inheritdoc DocBlock indentation

### DIFF
--- a/php_companion/commands/parse.py
+++ b/php_companion/commands/parse.py
@@ -73,7 +73,7 @@ class ParseCommand(sublime_plugin.TextCommand):
                     if get_setting("docblock_inherit") == True:
                         method = self.method_docblocks[method] + "\n\t" + method
                     elif get_setting("docblock_inherit") == "inheritdoc":
-                        method = "\n\t".join(["/**", " * {@inheritdoc}", "*/"]) + "\n\t" + method
+                        method = "\n\t".join(["/**", " * {@inheritdoc}", " */"]) + "\n\t" + method
 
                 pattern = ".+\s+function\s+([\w]+).+"
                 methodname = re.findall(pattern, method)[0]
@@ -86,7 +86,7 @@ class ParseCommand(sublime_plugin.TextCommand):
                 if self.method_docblocks[method] != None:
                     method = self.method_docblocks[method] + "\n\t" + method
             elif get_setting("docblock_inherit") == "inheritdoc":
-                method = "\n\t".join(["/**", " * {@inheritdoc}", "*/"]) + "\n\t" + method
+                method = "\n\t".join(["/**", " * {@inheritdoc}", " */"]) + "\n\t" + method
 
             pattern = ".+\s+function\s+([\w]+).+"
             methodname = re.findall(pattern, method)[0]


### PR DESCRIPTION
Thanks a lot for this plugin, can’t live without it!

Here’s a tiny bugfix which fixes incorrect indentation of the closing DocBlock line when auto-generating implementation method stubs from an interface.