### PR TITLE
Wipe off removed feature from settings file

### DIFF
--- a/PHP Companion.sublime-settings
+++ b/PHP Companion.sublime-settings
@@ -14,9 +14,6 @@
     // insert after opening tag
     "namespace_blank_lines": 2,
 
-    // Automatically import namespace on save
-    "enable_import_namespace_on_save": false,
-
     // Sort the list of use statements by their line length
     "use_sort_length": false,
 


### PR DESCRIPTION
The «auto-import on save» feature (sadly) seems to have been removed from the plugin, so I think the settings file should reflect that. I initially got confused as to why the feature wasn’t working (before discovering it was simply not there anymore).