### PR TITLE
Clarify how-to-use for find_use

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The package no longer provides keybindings. You will have to install your own sh
 
 ### find_use
 
-Just bring your cursor hover a class name, hit the <kbd>F5</kbd> key (personal shortcut) and that's it.
+Just place your cursor on a class name, hit the <kbd>F5</kbd> key (personal shortcut) and that's it.
 
 It will show you the different namespace that match your class, pick up one and you're done.
 


### PR DESCRIPTION
This including the word "hover" threw me when attempting to use `find_use`, since it seems to require the mouse cursor to be positioned in the class name, not just hovering over it.