### PR TITLE
import namespace: correct paths on windows systems

### DIFF
--- a/php_companion/commands/import_namespace_command.py
+++ b/php_companion/commands/import_namespace_command.py
@@ -11,7 +11,7 @@ class ImportNamespaceCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         projectPath = get_active_project_path()
         file_name = self.view.file_name().replace(projectPath, '')
-        if file_name.startswith('/'):
+        if file_name.startswith('/') or file_name.startswith('\\'):
             file_name = file_name[1:]
 
         # Abort if the file is not PHP

--- a/php_companion/utils.py
+++ b/php_companion/utils.py
@@ -83,8 +83,9 @@ def get_composer():
 def get_namespace(filename):
     data = get_composer()
     for _replace_with, _path in data['autoload']['psr-4'].items():
+		_path = normalize_to_system_style_path(_path)
         if _path.startswith('./'):
-            _path = _path[2:]     
+            _path = _path[2:]
 
         if filename.startswith(_path):
             namespace = filename.replace(_path, _replace_with)
@@ -92,8 +93,9 @@ def get_namespace(filename):
             return namespace.strip("\\").replace('\\\\', '\\')
 
     for _replace_with, _path in data['autoload-dev']['psr-4'].items():
+		_path = normalize_to_system_style_path(_path)
         if _path.startswith('./'):
-            _path = _path[2:]     
+            _path = _path[2:]
 
         if filename.startswith(_path):
             namespace = filename.replace(_path, _replace_with)


### PR DESCRIPTION
Os: Windows10
PHP Project: standard Laravel app
Issuing in SublimeText console after Import Namespace Command:

```
Traceback (most recent call last):
  File "[...]\SublimeText3\sublime_plugin.py", line 1088, in run_
    return self.run(edit)
  File "[...]\Data\Packages\PHP Companion\php_companion\commands\import_namespace_command.py", line 45, in run
    namespace_contents += 'namespace ' + namespace_stmt + ';'
TypeError: Can't convert 'NoneType' object to str implicitly
```

composer.json file

```json
"autoload": {
    "psr-4": {
        "App\\": "app/"
    },
}
```
I've inserted some small improvement on the file paths manage during the import namespace command